### PR TITLE
Make service_account_email optional

### DIFF
--- a/setup-gcloud/dist/index.js
+++ b/setup-gcloud/dist/index.js
@@ -8587,10 +8587,7 @@ function run() {
             if (!version) {
                 throw new Error('Missing required parameter: `version`');
             }
-            const serviceAccountEmail = core.getInput('service_account_email');
-            if (!serviceAccountEmail) {
-                throw new Error('Missing required input: `service_account_email`');
-            }
+            const serviceAccountEmail = core.getInput('service_account_email') || '';
             const serviceAccountKey = core.getInput('service_account_key');
             if (!serviceAccountKey) {
                 throw new Error('Missing required input: `service_account_key`');

--- a/setup-gcloud/src/setup-gcloud.ts
+++ b/setup-gcloud/src/setup-gcloud.ts
@@ -35,10 +35,7 @@ async function run() {
       throw new Error('Missing required parameter: `version`');
     }
 
-    const serviceAccountEmail = core.getInput('service_account_email');
-    if (!serviceAccountEmail) {
-      throw new Error('Missing required input: `service_account_email`');
-    }
+    const serviceAccountEmail = core.getInput('service_account_email') || '';
 
     const serviceAccountKey = core.getInput('service_account_key');
     if (!serviceAccountKey) {


### PR DESCRIPTION
This makes the action interface simpler, since the `service_account_email` argument is not
required when using a JSON service account key, it should be possible for the user to omit this option when it isn't needed.

[All tests passed](https://github.com/btorresgil/github-actions/commit/eb89c6b0ea48535b80574aee92c6ba8c94a0c4ef/checks?check_suite_id=314548720)