### PR TITLE
Top level action.yml

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -1,0 +1,17 @@
+name: 'Setup gcloud environment'
+description: 'Setup a gcloud environment and add it to the PATH'
+author: 'GoogleCloudPlatform'
+inputs:
+  version:
+    description: 'The version of the gcloud SDK to be installed.  Example: 270.0.0'
+    default: '270.0.0'
+    required: false
+  service_account_email:
+    description: 'The service account email which will be used for authentication.'
+    required: false
+  service_account_key:
+    description: 'The service account key which will be used for authentication.'
+    required: true
+runs:
+  using: 'node12'
+  main: 'setup-gcloud/dist/index.js'


### PR DESCRIPTION
Hi there 👋 Although it's recommended to keep actions in their own repos, this is a copy-paste of the `action.yml` from `setup-gcloud` to the top level of the repository, which will allow publishing `setup-gcloud` to the GitHub Marketplace.

If this PR is accepted as is, the action can be referenced in a workflow as either `uses: GoogleCloudPlatform/github-actions/setup-gcloud` or just `uses: GoogleCloudPlatform/github-actions`.


