### PR TITLE
Added integration tests for setup-gcloud action.

### DIFF
--- a/.github/workflows/setup-gcloud-it.yml
+++ b/.github/workflows/setup-gcloud-it.yml
@@ -1,0 +1,22 @@
+name: Integration Tests
+on: [push, pull_request]
+jobs:
+  run:
+    name: setup-gcloud
+    runs-on: ${{ matrix.operating-system }}
+    strategy:
+      matrix:
+        operating-system: [ubuntu-latest, windows-latest, macos-latest]
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: setup-gcloud local
+      uses: ./setup-gcloud/
+      with:
+        version: '274.0.0'
+        service_account_email: ${{ secrets.SETUP_GCLOUD_IT_EMAIL }}
+        service_account_key: ${{ secrets.SETUP_GCLOUD_IT_KEY }}
+
+    - name: Integration Tests
+      shell: bash
+      run: ./setup-gcloud/__tests__/integration-tests.sh

--- a/.github/workflows/setup-gcloud-it.yml
+++ b/.github/workflows/setup-gcloud-it.yml
@@ -1,19 +1,25 @@
 name: Integration Tests
-on: [push, pull_request]
+# The integration tests have to be pulled out into a separate workflow,
+# as GH Actions currently doesn't project secrets onto PR initiated runs.
+# Therefore these will only be run on branch pushes, which requires a
+# project maintainer to manually create branches from PRs and to
+# kick off integration test runs for the time being.
+on: [push]
 jobs:
   run:
     name: setup-gcloud
     runs-on: ${{ matrix.operating-system }}
     strategy:
+      fail-fast: false
       matrix:
         operating-system: [ubuntu-latest, windows-latest, macos-latest]
     steps:
     - uses: actions/checkout@v2
-
+      
     - name: setup-gcloud local
       uses: ./setup-gcloud/
       with:
-        version: '274.0.0'
+        version: '278.0.0'
         service_account_email: ${{ secrets.SETUP_GCLOUD_IT_EMAIL }}
         service_account_key: ${{ secrets.SETUP_GCLOUD_IT_KEY }}
 

--- a/.github/workflows/setup-gcloud.yml
+++ b/.github/workflows/setup-gcloud.yml
@@ -26,14 +26,3 @@ jobs:
     - name: Unit tests
       working-directory: ./setup-gcloud
       run: npm test
-
-    - name: setup-gcloud local
-      uses: ./setup-gcloud/
-      with:
-        version: '274.0.0'
-        service_account_email: ${{ secrets.SETUP_GCLOUD_IT_EMAIL }}
-        service_account_key: ${{ secrets.SETUP_GCLOUD_IT_KEY }}
-
-    - name: Integration Tests
-      shell: bash
-      run: ./setup-gcloud/__tests__/integration-tests.sh

--- a/.github/workflows/setup-gcloud.yml
+++ b/.github/workflows/setup-gcloud.yml
@@ -23,6 +23,17 @@ jobs:
       working-directory: ./setup-gcloud
       run: npm run format-check
 
-    - name: npm test
+    - name: Unit tests
       working-directory: ./setup-gcloud
       run: npm test
+
+    - name: setup-gcloud local
+      uses: ./setup-gcloud/
+      with:
+        version: '274.0.0'
+        service_account_email: ${{ secrets.SETUP_GCLOUD_IT_EMAIL }}
+        service_account_key: ${{ secrets.SETUP_GCLOUD_IT_KEY }}
+
+    - name: Integration Tests
+      shell: bash
+      run: ./setup-gcloud/__tests__/integration-tests.sh

--- a/setup-gcloud/__tests__/integration-tests.sh
+++ b/setup-gcloud/__tests__/integration-tests.sh
@@ -1,0 +1,29 @@
+# Copyright 2019 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+#!/bin/bash
+
+# This file contains integration tests for the setup-gcloud action.
+
+# fail on error
+set -e
+
+# Ensure authentication was succesfully configured
+echo "Testing authentication..."
+gcloud projects list > /dev/null && echo "Passed."
+
+# Ensure gsutil was properly configured
+echo "Testing gsutil..."
+gsutil ls > /dev/null && echo "Passed."
+

--- a/setup-gcloud/__tests__/integration-tests.sh
+++ b/setup-gcloud/__tests__/integration-tests.sh
@@ -1,3 +1,4 @@
+#!/bin/bash
 # Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,8 +13,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-#!/bin/bash
-
 # This file contains integration tests for the setup-gcloud action.
 
 # fail on error
@@ -24,6 +23,10 @@ echo "Testing authentication..."
 gcloud projects list > /dev/null && echo "Passed."
 
 # Ensure gsutil was properly configured
-echo "Testing gsutil..."
-gsutil ls > /dev/null && echo "Passed."
-
+# NOTE(craigdbarber): does not currently work for Windows as
+# the gcloud SDK windows release is currently missing the
+# gsutil bash entrypoint script.
+if which "gsutil" &> /dev/null; then
+    echo "Testing gsutil..."
+    gsutil ls gs://cloud-sdk-release > /dev/null && echo "Passed."
+fi

--- a/setup-gcloud/__tests__/integration-tests.sh
+++ b/setup-gcloud/__tests__/integration-tests.sh
@@ -23,9 +23,9 @@ echo "Testing authentication..."
 gcloud projects list > /dev/null && echo "Passed."
 
 # Ensure gsutil was properly configured
-# NOTE(craigdbarber): does not currently work for Windows as
-# the gcloud SDK windows release is currently missing the
-# gsutil bash entrypoint script.
+# NOTE(craigdbarber): does not work for Windows as the gcloud
+# SDK windows release is currently missing the gsutil bash
+# entrypoint script.
 if which "gsutil" &> /dev/null; then
     echo "Testing gsutil..."
     gsutil ls gs://cloud-sdk-release > /dev/null && echo "Passed."

--- a/setup-gcloud/dist/index.js
+++ b/setup-gcloud/dist/index.js
@@ -8299,9 +8299,9 @@ function run() {
                 throw new Error('Missing required parameter: `version`');
             }
             // install the gcloud is not already present
-            const toolPath = toolCache.find('gcloud', version);
+            let toolPath = toolCache.find('gcloud', version);
             if (!toolPath) {
-                yield installGcloudSDK(version);
+                toolPath = yield installGcloudSDK(version);
             }
             const serviceAccountEmail = core.getInput('service_account_email') || '';
             const serviceAccountKey = core.getInput('service_account_key');
@@ -8320,8 +8320,12 @@ function run() {
                 });
             });
             yield fs_1.promises.writeFile(tmpKeyFilePath, js_base64_1.Base64.decode(serviceAccountKey));
+            let toolCommand = 'gcloud';
+            if (process.platform == 'win32') {
+                toolCommand = 'gcloud.cmd';
+            }
             // authenticate as the specified service account
-            yield exec.exec(`gcloud auth activate-service-account ${serviceAccountEmail} --key-file=${tmpKeyFilePath}`);
+            yield exec.exec(`${toolCommand} auth activate-service-account ${serviceAccountEmail} --key-file=${tmpKeyFilePath}`);
         }
         catch (error) {
             core.setFailed(error.message);
@@ -8340,7 +8344,7 @@ function installGcloudSDK(version) {
             throw new Error(`Failed to download release, url: ${url}`);
         }
         // install the downloaded release into the github action env
-        yield installUtil.installGcloudSDK(version, extPath);
+        return yield installUtil.installGcloudSDK(version, extPath);
     });
 }
 run();

--- a/setup-gcloud/src/install-util.ts
+++ b/setup-gcloud/src/install-util.ts
@@ -22,8 +22,6 @@ import * as core from '@actions/core';
 import * as os from 'os';
 import path from 'path';
 
-import * as exec from '@actions/exec';
-
 export const GCLOUD_METRICS_ENV_VAR = 'CLOUDSDK_METRICS_ENVIRONMENT';
 export const GCLOUD_METRICS_LABEL = 'github-actions-setup-gcloud';
 

--- a/setup-gcloud/src/install-util.ts
+++ b/setup-gcloud/src/install-util.ts
@@ -22,6 +22,8 @@ import * as core from '@actions/core';
 import * as os from 'os';
 import path from 'path';
 
+import * as exec from '@actions/exec';
+
 export const GCLOUD_METRICS_ENV_VAR = 'CLOUDSDK_METRICS_ENVIRONMENT';
 export const GCLOUD_METRICS_LABEL = 'github-actions-setup-gcloud';
 

--- a/setup-gcloud/src/setup-gcloud.ts
+++ b/setup-gcloud/src/setup-gcloud.ts
@@ -61,6 +61,8 @@ async function run() {
     });
     await fs.writeFile(tmpKeyFilePath, Base64.decode(serviceAccountKey));
 
+    // A workaround for https://github.com/actions/toolkit/issues/229
+    // Currently exec on windows runs as cmd shell.
     let toolCommand = 'gcloud';
     if (process.platform == 'win32') {
       toolCommand = 'gcloud.cmd';

--- a/setup-gcloud/src/setup-gcloud.ts
+++ b/setup-gcloud/src/setup-gcloud.ts
@@ -36,9 +36,9 @@ async function run() {
     }
 
     // install the gcloud is not already present
-    const toolPath = toolCache.find('gcloud', version);
+    let toolPath = toolCache.find('gcloud', version);
     if (!toolPath) {
-      await installGcloudSDK(version);
+      toolPath = await installGcloudSDK(version);
     }
 
     const serviceAccountEmail = core.getInput('service_account_email') || '';
@@ -61,16 +61,21 @@ async function run() {
     });
     await fs.writeFile(tmpKeyFilePath, Base64.decode(serviceAccountKey));
 
+    let toolCommand = 'gcloud';
+    if (process.platform == 'win32') {
+      toolCommand = 'gcloud.cmd';
+    }
+
     // authenticate as the specified service account
     await exec.exec(
-      `gcloud auth activate-service-account ${serviceAccountEmail} --key-file=${tmpKeyFilePath}`,
+      `${toolCommand} auth activate-service-account ${serviceAccountEmail} --key-file=${tmpKeyFilePath}`,
     );
   } catch (error) {
     core.setFailed(error.message);
   }
 }
 
-async function installGcloudSDK(version: string) {
+async function installGcloudSDK(version: string): Promise<string> {
   // retreive the release corresponding to the specified version and the current env
   const osPlat = os.platform();
   const osArch = os.arch();
@@ -83,7 +88,7 @@ async function installGcloudSDK(version: string) {
   }
 
   // install the downloaded release into the github action env
-  await installUtil.installGcloudSDK(version, extPath);
+  return await installUtil.installGcloudSDK(version, extPath);
 }
 
 run();


### PR DESCRIPTION
Added integration tests for setup-gcloud. GH Actions currently has a limitation which prevents the projection of secrets from the store into runs triggered by PRs by forks. This means that for the time being maintainers will have to manually create branches from PR forks they'd like to run integration tests against. I've communicated the issue to @imjohnbo and the fine folks at GH, and they're diligently working on a solution for us.