### PR TITLE
Document export_default_credentials file creation

### DIFF
--- a/setup-gcloud/README.md
+++ b/setup-gcloud/README.md
@@ -62,7 +62,7 @@ steps:
 
 * `service_account_key`: (Optional) The service account key which will be used for authentication. This key should be [created](https://cloud.google.com/iam/docs/creating-managing-service-account-keys), encoded as a [Base64](https://en.wikipedia.org/wiki/Base64) string (eg. `cat my-key.json | base64` on macOS), and stored as a [secret](https://help.github.com/en/actions/automating-your-workflow-with-github-actions/creating-and-using-encrypted-secrets).
 
-* `export_default_credentials`: (Optional) Export the provided credentials as [Google Default Application Credentials][dac]. This will make the credentials available to later steps. Future steps that consume Default Application Credentials will automatically detect and use these credentials.
+* `export_default_credentials`: (Optional) Export the provided credentials as [Google Default Application Credentials][dac]. This will make the credentials available to later steps. Future steps that consume Default Application Credentials will automatically detect and use these credentials. Every time the action is run, this will generate a temporary file in the root of the repository with a random name, to hold the exported credentials.
 
 [dac]: https://cloud.google.com/docs/authentication/production
 [sdk]: https://cloud.google.com/sdk/


### PR DESCRIPTION
Document the fact that turning on export_default_credentials will cause a file to be generated

Addresses https://github.com/GoogleCloudPlatform/github-actions/issues/65