### PR TITLE
Unify action.yaml format

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -1,17 +1,55 @@
-name: 'Setup gcloud environment'
-description: 'Setup a gcloud environment and add it to the PATH'
-author: 'GoogleCloudPlatform'
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+name: Set up gcloud Cloud SDK environment
+author: GoogleCloudPlatform
+description: |-
+  Downloads, installs, and configures a gcloud Cloud SDK environment for the
+  worker. This will add the `gcloud` CLI command to the worker's $PATH.
+
 inputs:
   version:
-    description: 'The version of the gcloud SDK to be installed.  Example: 275.0.0'
-    default: '275.0.0'
+    description: |-
+      Version of the gcloud SDK to install. If unspecified or set to "latest",
+      the latest available gcloud SDK version for the target platform will be
+      installed. Example: "278.0.0".
+    default: latest
     required: false
+
   service_account_email:
-    description: 'The service account email which will be used for authentication.'
+    description: |-
+      Service account email address to use for authentication. This is usually
+      of the format <name>@<project-id>.iam.gserviceaccount.com.
     required: false
+
   service_account_key:
-    description: 'The service account key which will be used for authentication.'
+    description: |-
+      Service account key to use for authentication. This should be the JSON
+      formatted private key which can be exported from the Cloud Console. The
+      value can be raw or base64-encoded.
     required: true
+
+  export_default_credentials:
+    description: |-
+      Export the provided credentials as Google Default Application Credentials.
+      This will make the credentials available to later steps via the
+      GOOGLE_APPLICATION_CREDENTIALS environment variable. Future steps that
+      consume Default Application Credentials will automatically detect and use
+      these credentials.
+    default: false
+    required: false
+
 runs:
-  using: 'node12'
-  main: 'setup-gcloud/dist/index.js'
+  using: node12
+  main: setup-gcloud/dist/index.js

--- a/get-secretmanager-secrets/action.yml
+++ b/get-secretmanager-secrets/action.yml
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 name: Get Secret Manager secrets
-author: Google Cloud
+author: GoogleCloudPlatform
 description: |-
   Get secrets from Google Secret Manager and make their results available as
   output variables. See https://cloud.google.com/secret-manager for more

--- a/setup-gcloud/action.yml
+++ b/setup-gcloud/action.yml
@@ -12,20 +12,34 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-name: 'Setup gcloud environment'
-description: 'Setup a gcloud environment and add it to the PATH'
-author: 'GoogleCloudPlatform'
+name: Set up gcloud Cloud SDK environment
+author: GoogleCloudPlatform
+description: |-
+  Downloads, installs, and configures a gcloud Cloud SDK environment for the
+  worker. This will add the `gcloud` CLI command to the worker's $PATH.
+
 inputs:
   version:
-    description: 'The version of the gcloud SDK to be installed.  Example: 278.0.0'
-    default: 'latest'
+    description: |-
+      Version of the gcloud SDK to install. If unspecified or set to "latest",
+      the latest available gcloud SDK version for the target platform will be
+      installed. Example: "278.0.0".
+    default: latest
     required: false
+
   service_account_email:
-    description: 'The service account email which will be used for authentication.'
+    description: |-
+      Service account email address to use for authentication. This is usually
+      of the format <name>@<project-id>.iam.gserviceaccount.com.
     required: false
+
   service_account_key:
-    description: 'The service account key which will be used for authentication.'
+    description: |-
+      Service account key to use for authentication. This should be the JSON
+      formatted private key which can be exported from the Cloud Console. The
+      value can be raw or base64-encoded.
     required: true
+
   export_default_credentials:
     description: |-
       Export the provided credentials as Google Default Application Credentials.
@@ -35,6 +49,7 @@ inputs:
       these credentials.
     default: false
     required: false
+
 runs:
-  using: 'node12'
-  main: 'dist/index.js'
+  using: node12
+  main: dist/index.js


### PR DESCRIPTION
There was some disparity around the author field and also some discrepancies between the root action.yaml and the setup-gcloud action.yaml. This also improve the description of some of the attributes.