### PR TITLE
Add GitHub issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.md
+++ b/.github/ISSUE_TEMPLATE/bug.md
@@ -1,0 +1,33 @@
+---
+name: Bug report
+about: Tell us about a bug.
+labels: bug
+---
+
+### TL;DR
+<!-- Describe the bug in 1-2 sentences below. -->
+
+**Expected behavior**
+<!-- What did you expect to happen? Please share below. -->
+
+**Observed behavior**
+<!-- What did happened instead? Please share below. -->
+
+
+### Reproduction
+
+**Action YAML**
+<!-- Add your complete GitHub Actions YAML below. -->
+
+```yaml
+# Paste your complete GitHub Actions YAML here, removing
+# any sensitive values.
+```
+
+**Repository**
+<!-- Is your repository public? If so, please link to it. -->
+<!-- If your repository is not public, delete this section. -->
+
+
+**Additional information**
+<!-- Are you running custom workers? Doing something atypical? Etc? -->

--- a/.github/ISSUE_TEMPLATE/feature.md
+++ b/.github/ISSUE_TEMPLATE/feature.md
@@ -1,0 +1,28 @@
+---
+name: Feature
+about: Request a new feature or functionality.
+labels: feature
+---
+
+### TL;DR
+<!-- Describe the feature in 1-2 sentences below. -->
+
+
+### Design
+
+**Action YAML**
+<!-- What do you envision the action to look like?  -->
+<!-- If this is not relevant, delete this section. -->
+
+```yaml
+# Paste your proposed GitHub Actions YAML here.
+```
+
+**Resources**
+<!-- Please provide links to relevant documentation or examples. -->
+
+- [Link to documentation](TODO)
+
+
+**Additional information**
+<!-- Are you running custom workers? Doing something atypical? Etc? -->

--- a/.github/ISSUE_TEMPLATE/question.md
+++ b/.github/ISSUE_TEMPLATE/question.md
@@ -1,0 +1,9 @@
+---
+name: Question
+about: Ask us a question.
+labels: question
+---
+
+### Question
+<!-- Ask your question in 1-2 sentences below. -->
+<!-- If sharing code, please use ``` codeblocks -->


### PR DESCRIPTION
This adds an initial issue template (we can iterate on it in the future) to help reduce the back-and-forth with bug reports.