### PR TITLE
Only run CI checks that correspond to changed files

### DIFF
--- a/.github/workflows/get-secretmanager-secrets-it.yml
+++ b/.github/workflows/get-secretmanager-secrets-it.yml
@@ -1,5 +1,10 @@
 name: get-secretmanager-secrets Integration
-on: [push]
+
+on:
+  push:
+    paths:
+    - 'get-secretmanager-secrets/**'
+
 jobs:
   gcloud:
     name: with setup-gcloud

--- a/.github/workflows/get-secretmanager-secrets.yml
+++ b/.github/workflows/get-secretmanager-secrets.yml
@@ -1,5 +1,13 @@
 name: get-secretmanager-secrets Unit
-on: [push, pull_request]
+
+on:
+  push:
+    paths:
+    - 'get-secretmanager-secrets/**'
+  pull_request:
+    paths:
+    - 'get-secretmanager-secrets/**'
+
 jobs:
   run:
     name: test

--- a/.github/workflows/setup-gcloud-it.yml
+++ b/.github/workflows/setup-gcloud-it.yml
@@ -1,10 +1,15 @@
 name: setup-gcloud Integration
+
 # The integration tests have to be pulled out into a separate workflow,
 # as GH Actions currently doesn't project secrets onto PR initiated runs.
 # Therefore these will only be run on branch pushes, which requires a
 # project maintainer to manually create branches from PRs and to
 # kick off integration test runs for the time being.
-on: [push]
+on:
+  push:
+    paths:
+    - 'setup-gcloud/**'
+
 jobs:
   versioned:
     name: setup-gcloud versioned

--- a/.github/workflows/setup-gcloud.yml
+++ b/.github/workflows/setup-gcloud.yml
@@ -1,5 +1,13 @@
 name: setup-gcloud Unit
-on: [push, pull_request]
+
+on:
+  push:
+    paths:
+    - 'setup-gcloud/**'
+  pull_request:
+    paths:
+    - 'setup-gcloud/**'
+
 jobs:
   run:
     name: setup-gcloud


### PR DESCRIPTION
This reduces the number of tests we need to run by mapping the tests to the files changed.