### PR TITLE
Update to latest gcloud version in docs

### DIFF
--- a/.github/workflows/setup-gcloud-it.yml
+++ b/.github/workflows/setup-gcloud-it.yml
@@ -24,7 +24,7 @@ jobs:
     - name: setup-gcloud
       uses: ./setup-gcloud/
       with:
-        version: '278.0.0'
+        version: '286.0.0'
         service_account_email: ${{ secrets.SETUP_GCLOUD_IT_EMAIL }}
         service_account_key: ${{ secrets.SETUP_GCLOUD_IT_KEY }}
 

--- a/action.yml
+++ b/action.yml
@@ -23,7 +23,7 @@ inputs:
     description: |-
       Version of the gcloud SDK to install. If unspecified or set to "latest",
       the latest available gcloud SDK version for the target platform will be
-      installed. Example: "278.0.0".
+      installed. Example: "286.0.0".
     default: latest
     required: false
 

--- a/setup-gcloud/action.yml
+++ b/setup-gcloud/action.yml
@@ -23,7 +23,7 @@ inputs:
     description: |-
       Version of the gcloud SDK to install. If unspecified or set to "latest",
       the latest available gcloud SDK version for the target platform will be
-      installed. Example: "278.0.0".
+      installed. Example: "286.0.0".
     default: latest
     required: false
 


### PR DESCRIPTION
This isn't technically necessary because the default is "latest", but I've noticed a lot of people copy-paste examples and then end up with an outdated gcloud version.