### PR TITLE
Update kubectl rollout status command

### DIFF
--- a/example-workflows/gke/.github/workflows/gke.yml
+++ b/example-workflows/gke/.github/workflows/gke.yml
@@ -76,5 +76,5 @@ jobs:
       run: |-
         ./kustomize edit set image gcr.io/PROJECT_ID/IMAGE:TAG=gcr.io/$PROJECT_ID/$IMAGE:$GITHUB_SHA
         ./kustomize build . | kubectl apply -f -
-        kubectl rollout status deployment/gke-test
+        kubectl rollout status deployment/$IMAGE
         kubectl get services -o wide


### PR DESCRIPTION
In the current example it is hardcoded to `gke-test` but that will fail if people follow the tutorial in the README.md and change the IMAGE name