### PR TITLE
Issue #108: add '--quiet' flag to gae example

### DIFF
--- a/example-workflows/gae/.github/workflows/app-engine.yml
+++ b/example-workflows/gae/.github/workflows/app-engine.yml
@@ -38,4 +38,4 @@ jobs:
       # Deploy App to App Engine
       - name: Deploy
         run: |
-          gcloud app deploy
+          gcloud app deploy --quiet


### PR DESCRIPTION
Application failed to deploy in CI environment for GAE example because it used the interactive deployment prompt.

Resolves issue #108.