### PR TITLE
Fix appengine-deploy action to read from image_url param correctly

### DIFF
--- a/appengine-deploy/README.md
+++ b/appengine-deploy/README.md
@@ -52,7 +52,7 @@ steps:
   automatically generate necessary configuration files (such as app.yaml) in
   the current directory (example, `app.yaml cron.yaml`).
 
-- `image-url`: (Optional) Deploy with a specific container image. The image url
+- `image_url`: (Optional) Deploy with a specific container image. The image url
   must be from one of the valid GCR hostnames (example, `gcr.io/`).
 
 - `version`: (Optional) The version of the app that will be created or replaced

--- a/appengine-deploy/dist/index.js
+++ b/appengine-deploy/dist/index.js
@@ -1001,7 +1001,7 @@ function run() {
             // Get action inputs.
             let projectId = core.getInput('project_id');
             const deliverables = core.getInput('deliverables');
-            const imageUrl = core.getInput('image-url');
+            const imageUrl = core.getInput('image_url');
             const version = core.getInput('version');
             const promote = core.getInput('promote');
             const serviceAccountKey = core.getInput('credentials');
@@ -1029,7 +1029,12 @@ function run() {
             }
             const toolCommand = setupGcloud.getToolCommand();
             // Create app engine gcloud cmd.
-            const appDeployCmd = ['app', 'deploy', '--quiet', ...deliverables.split(' ')];
+            const appDeployCmd = [
+                'app',
+                'deploy',
+                '--quiet',
+                ...deliverables.split(' '),
+            ];
             // Add gcloud flags.
             if (projectId !== '') {
                 appDeployCmd.push('--project', projectId);

--- a/appengine-deploy/src/main.ts
+++ b/appengine-deploy/src/main.ts
@@ -23,7 +23,7 @@ async function run(): Promise<void> {
     // Get action inputs.
     let projectId = core.getInput('project_id');
     const deliverables = core.getInput('deliverables');
-    const imageUrl = core.getInput('image-url');
+    const imageUrl = core.getInput('image_url');
     const version = core.getInput('version');
     const promote = core.getInput('promote');
     const serviceAccountKey = core.getInput('credentials');


### PR DESCRIPTION
The action.yml specifies an `image_url` param, but `main.ts` is looking for an `image-url` parameter instead, and so any `image_url` passed in gets silently dropped. (And `image-url` isn't grammatically valid as an action-parameter identifier, so you can't just pass that in, either.)

I fixed `main.ts`, and ran `npm run build` to regenerate `dist/`. Also updated README.md to refer to the parameter as `image_url`.