### PR TITLE
feat: separate steps for releas-please

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -27,7 +27,7 @@ jobs:
           git pull --rebase
           git push origin master
         working-directory: ${{ matrix.actions }}
-  release:
+  release-please-pr:
     runs-on: ubuntu-latest
     needs: [build]
     strategy:
@@ -41,3 +41,20 @@ jobs:
           fork: true
           package-name: ${{ matrix.actions }}
           path: ${{ matrix.actions }}
+          monorepo-tags: ${{ matrix.actions }}
+          command: release-pr
+  release-please-release:
+    runs-on: ubuntu-latest
+    needs: [build]
+    strategy:
+        matrix: 
+          actions: ["setupGcloudSDK", "appengine-deploy","deploy-cloudrun", "setup-gcloud", "get-secretmanager-secrets", "upload-cloud-storage"]
+    steps:
+      - uses: GoogleCloudPlatform/release-please-action@main
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          release-type: node
+          package-name: ${{ matrix.actions }}
+          path: ${{ matrix.actions }}
+          monorepo-tags: ${{ matrix.actions }}
+          command: github-release


### PR DESCRIPTION
- separates release-please action into 2 parts
    - `release-pr` creates the release pr from a fork using robot account
    - `github-release` which creates the release is done using regular token

- added `monorepo-tags` to identify individual action release-branch PRs. Example: https://github.com/bharathkkb/github-actions/pulls